### PR TITLE
Upgrading nan to 2.14.1 for latest V8 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "nan": "2.14.0"
+    "nan": "2.14.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
nan <= `2.14.0` uses removed methods, upgrading to 2.14.1 to incorporate [these](https://github.com/nodejs/nan/commit/2c023bd447661a61071da318b0ff4003c3858d39) changes.